### PR TITLE
Sectv-tizen packager should prepare absolute path

### DIFF
--- a/tasks/packager/sectv-tizen.js
+++ b/tasks/packager/sectv-tizen.js
@@ -172,6 +172,9 @@ function prepareDir(dir) {
     dir = path.resolve(dir);
     var tmp = dir.split(path.sep);
     var curPath = tmp[0];
+    if(path.isAbsolute(dir)){
+        curPath = path.join(path.sep, curPath);
+    }
     for (var i=1; i<tmp.length; i++) {
         curPath = path.join(curPath, tmp[i]);
         if (!fs.existsSync(curPath)) {


### PR DESCRIPTION
Check if dir is absolute and make proper current path. If the dir argument is absolute path then prepareDir function makes tree structure inside current path instead of root dir.
