### PR TITLE
Extend appinfo configuration

### DIFF
--- a/tasks/packager/tv-webos.js
+++ b/tasks/packager/tv-webos.js
@@ -101,17 +101,11 @@ function validateWebosVersion(version) {
 function confirmUseExistingData(userData, callback) {
     console.log('');
     console.log('      > [ Stored Information ]');
-    console.log('      > id                 : ' + userData.id);
-    console.log('      > name               : ' + userData.name);
-    console.log('      > version            : ' + userData.version);
-    console.log('      > vendor             : ' + userData.vendor);
-    console.log('      > icon               : ' + userData.icon);
-    console.log('      > largeIcon          : ' + userData.largeicon);
-    console.log('      > resolution         : ' + userData.resolution);
-    console.log('      > bgColor            : ' + userData.bgcolor);
-    console.log('      > iconColor          : ' + userData.iconcolor);
-    console.log('      > splashBackground   : ' + userData.splashbackground);
-    console.log('      > bgImage            : ' + userData.bgimage);
+    console.log('      > id          : ' + userData.id);
+    console.log('      > name        : ' + userData.name);
+    console.log('      > version     : ' + userData.version);
+    console.log('      > vendor      : ' + userData.vendor);
+    console.log('      > resolution  : ' + userData.resolution);
 
     var ask = [{
         type: 'confirm',
@@ -211,7 +205,7 @@ function askUserData(cordovaConf, callback, versionOnly, userData) {
             type: 'input',
             name: 'bgcolor',
             message: 'Background color for app',
-            default: 'red',
+            default: 'white',
             validate: function(input) {
                 return typeof(input) === 'string' ? true : 'invalid color';
             }
@@ -219,7 +213,7 @@ function askUserData(cordovaConf, callback, versionOnly, userData) {
             type: 'input',
             name: 'iconcolor',
             message: 'Icon color for app',
-            default: 'red',
+            default: 'white',
             validate: function(input) {
                 return typeof(input) === 'string' ? true : 'invalid color';
             }

--- a/tasks/packager/tv-webos.js
+++ b/tasks/packager/tv-webos.js
@@ -101,11 +101,15 @@ function validateWebosVersion(version) {
 function confirmUseExistingData(userData, callback) {
     console.log('');
     console.log('      > [ Stored Information ]');
-    console.log('      > id          : ' + userData.id);
-    console.log('      > name        : ' + userData.name);
-    console.log('      > version     : ' + userData.version);
-    console.log('      > vendor      : ' + userData.vendor);
-    console.log('      > resolution  : ' + userData.resolution);
+    console.log('      > id                 : ' + userData.id);
+    console.log('      > name               : ' + userData.name);
+    console.log('      > version            : ' + userData.version);
+    console.log('      > vendor             : ' + userData.vendor);
+    console.log('      > resolution         : ' + userData.resolution);
+    console.log('      > bgColor            : ' + userData.bgColor);
+    console.log('      > iconColor          : ' + userData.iconColor);
+    console.log('      > splashBackground   : ' + userData.splashBackground);
+    console.log('      > bgImage            : ' + userData.bgImage);
 
     var ask = [{
         type: 'confirm',
@@ -184,6 +188,38 @@ function askUserData(cordovaConf, callback, versionOnly, userData) {
             default: 'img/logo.png',
             validate: function(input) {
                 return typeof(input) === 'string' ? true : 'invalid iconpath';
+            }
+        }, {
+            type: 'input',
+            name: 'bgImage',
+            message: 'Background image path (default is \'img/logo.png\')',
+            default: 'img/logo.png',
+            validate: function(input) {
+                return typeof(input) === 'string' ? true : 'invalid path';
+            }
+        }, {
+            type: 'input',
+            name: 'splashBackground',
+            message: 'Splash screen background path (default is \'img/logo.png\')',
+            default: 'img/logo.png',
+            validate: function(input) {
+                return typeof(input) === 'string' ? true : 'invalid path';
+            }
+        }, {
+            type: 'input',
+            name: 'bgColor',
+            message: 'Background color for app',
+            default: 'red',
+            validate: function(input) {
+                return typeof(input) === 'string' ? true : 'invalid color';
+            }
+        }, {
+            type: 'input',
+            name: 'iconColor',
+            message: 'Icon color for app',
+            default: 'red',
+            validate: function(input) {
+                return typeof(input) === 'string' ? true : 'invalid color';
             }
         }, {
             type: 'list',

--- a/tasks/packager/tv-webos.js
+++ b/tasks/packager/tv-webos.js
@@ -105,11 +105,13 @@ function confirmUseExistingData(userData, callback) {
     console.log('      > name               : ' + userData.name);
     console.log('      > version            : ' + userData.version);
     console.log('      > vendor             : ' + userData.vendor);
+    console.log('      > icon               : ' + userData.icon);
+    console.log('      > largeIcon          : ' + userData.largeicon);
     console.log('      > resolution         : ' + userData.resolution);
-    console.log('      > bgColor            : ' + userData.bgColor);
-    console.log('      > iconColor          : ' + userData.iconColor);
-    console.log('      > splashBackground   : ' + userData.splashBackground);
-    console.log('      > bgImage            : ' + userData.bgImage);
+    console.log('      > bgColor            : ' + userData.bgcolor);
+    console.log('      > iconColor          : ' + userData.iconcolor);
+    console.log('      > splashBackground   : ' + userData.splashbackground);
+    console.log('      > bgImage            : ' + userData.bgimage);
 
     var ask = [{
         type: 'confirm',
@@ -191,7 +193,7 @@ function askUserData(cordovaConf, callback, versionOnly, userData) {
             }
         }, {
             type: 'input',
-            name: 'bgImage',
+            name: 'bgimage',
             message: 'Background image path (default is \'img/logo.png\')',
             default: 'img/logo.png',
             validate: function(input) {
@@ -199,7 +201,7 @@ function askUserData(cordovaConf, callback, versionOnly, userData) {
             }
         }, {
             type: 'input',
-            name: 'splashBackground',
+            name: 'splashbackground',
             message: 'Splash screen background path (default is \'img/logo.png\')',
             default: 'img/logo.png',
             validate: function(input) {
@@ -207,7 +209,7 @@ function askUserData(cordovaConf, callback, versionOnly, userData) {
             }
         }, {
             type: 'input',
-            name: 'bgColor',
+            name: 'bgcolor',
             message: 'Background color for app',
             default: 'red',
             validate: function(input) {
@@ -215,7 +217,7 @@ function askUserData(cordovaConf, callback, versionOnly, userData) {
             }
         }, {
             type: 'input',
-            name: 'iconColor',
+            name: 'iconcolor',
             message: 'Icon color for app',
             default: 'red',
             validate: function(input) {


### PR DESCRIPTION
On WebOS, you are able to configure application icon background, splash screen, and hover image from appinfo.json.
With this pull request, developers are able to configure the webOS builds better.

This pull request is connected to my [cordova-tv-webos](https://github.com/Samsung/cordova-tv-webos/pull/1) request.