### PR TITLE
Bad output by getManualOrsayConfData

### DIFF
--- a/tasks/packager/sectv-orsay.js
+++ b/tasks/packager/sectv-orsay.js
@@ -323,7 +323,7 @@ function getManualOrsayConfData(platformsData){
         for (i=0; i < platformsData.length; i++) {
             if (platformsData[i].$.name === 'sectv-orsay') {
                 delete platformsData[i].$;
-                manualOrsayConfData = utils.trim(js2xmlparser('platform',platformsData[i],{declaration : {include : false},attributeString : '$'}).replace(/<(\/?platform)>/igm,''));
+                manualOrsayConfData = utils.trim(js2xmlparser('platform',platformsData[i],{declaration : {include : false},attributeString : '$', valueString: '_'}).replace(/<(\/?platform)>/igm,''));
             }
         }
     }


### PR DESCRIPTION
In orsay if the config.xml contains a tag like '\<tiker\>y\</tiker\>' it will output '\<tiker\>\<\_\>y\</\_\>\</tiker\>' because the '\_' is the default string used by xml2js lib to represent the node value.
Adding {valueString: '_'} to the js2xmlparser options seems to solve the problem.
This is presents in all tizen, orsay and webOs tasks.